### PR TITLE
add result page layout in `src/views`

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -258,3 +258,39 @@ a.secondary {
 * > a ~ a:last-child {
   margin-top: 1.5em;
 }
+
+.result-visual {
+  width: 100%;
+  display: flex;
+  align-items: stretch;
+  justify-content: space-evenly;
+}
+
+.result-visual > div:nth-child(2) {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-around;
+}
+
+.result-visual__svgContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-weight: 700;
+  text-align: center;
+}
+
+.result-visual svg {
+  stroke-width: 2px;
+  --svg-normalizer: 0.13;
+  font-weight: bold;
+  font-size: 24px;
+}
+
+@media only screen and (max-width: 600px) {
+  .result-visual svg {
+    --svg-normalizer: 0.2;
+    font-size: 16px;
+  }
+}

--- a/src/start.mjs
+++ b/src/start.mjs
@@ -18,6 +18,7 @@ import contact from "./views/contact.mjs";
 import markdown from "./views/markdown.mjs";
 import success from "./views/success.mjs";
 import vote from "./views/vote.mjs";
+import result from './views/result.mjs'
 import apiV1 from "./api/v1/index.mjs";
 
 const { SERVER_PORT, NODE_ENV } = process.env;
@@ -79,6 +80,23 @@ fastify.get("/about", async (request, reply) => {
     .code(200)
     .type("text/html")
     .send(content);
+});
+
+fastify.get("/result", (request, reply) => {
+  return reply
+    .code(200)
+    .type("text/html")
+    .send(
+      result(
+        [
+          { optionID: 1, votes: 950, text: "Bundeskunsthalle’s proposal" },
+          { optionID: 3, votes: 130, text: "Public good's proposal" },
+          { optionID: 2, votes: 340, text: "DoD’s proposal" }
+        ],
+        1420,
+        50
+      )
+    );
 });
 
 fastify.register(apiV1, { prefix: "/api/v1" });

--- a/src/views/result.mjs
+++ b/src/views/result.mjs
@@ -1,0 +1,144 @@
+//@format
+import htm from "htm";
+import vhtml from "vhtml";
+const html = htm.bind(vhtml);
+
+import head from "./head.mjs";
+import Navigation from "./navigation.mjs";
+
+const config = {
+  title: "StrikeDAO - Vote"
+};
+
+// result expects an array of {optionID: 1, votes: 2, text: 'Some Text'}
+export default (result, totalVotes, noOfVotes) => {
+  const radius = result.map(({ votes }) => Math.sqrt(votes / totalVotes));
+
+  return html`
+    <html>
+      <head>
+        ${head(config)}
+      </head>
+      <body>
+        <${Navigation} />
+        <section style="margin-top: 50px">
+          <section style="display: block; margin-bottom: 18px; ">
+            <video
+              controls
+              loop
+              src="public/result.mp4"
+              type="video/mp4"
+              width="100%"
+            ></video>
+            <div
+              style="width: 75px; height: 7px; background-color: #F1F1F1;"
+            ></div>
+          </section>
+          <section>
+            <p>
+              The initial video is rearranged according to the results and
+              temporal order of the voting process. Stills that were used to
+              support the winning proposal are displayed first, etc.
+            </p>
+            <h2 style="margin-bottom: 0px;">DoD's proposal won the vote!</h2>
+            <p style="text-align: center;">
+              Total Votes: ${totalVotes} <br />
+              Number of Votes: ${noOfVotes} votes
+            </p>
+
+            <div class="result-visual">
+              <div
+                class="result-visual__svgContainer"
+                style="justify-content: center;"
+              >
+                <svg
+                  style="stroke: white; 
+                width: calc(${radius[0] * 2} * 100vw * var(--svg-normalizer)); 
+                height: calc(${radius[0] * 2} * 100vw * var(--svg-normalizer));"
+                >
+                  <circle cx="50%" cy="50%" r="49%"></circle>
+                  <text
+                    x="50%"
+                    y="50%"
+                    text-anchor="middle"
+                    dy="0.3em"
+                    fill="white"
+                    stroke="none"
+                  >
+                    ${result[0].votes}
+                  </text>
+                </svg>
+                <span
+                  style="margin-top: 10px;
+                    max-width: calc(${radius[0] *
+                  2} * 100vw * var(--svg-normalizer))"
+                  >${result[0].text}</span
+                >
+                <span>${result[0].votes}</span>
+              </div>
+              <div>
+                <div class="result-visual__svgContainer">
+                  <svg
+                    style="stroke: white;
+                  width: calc(${radius[1] * 2} * 100vw * var(--svg-normalizer));
+                  height: calc(${radius[1] *
+                    2} * 100vw * var(--svg-normalizer));"
+                  >
+                    <circle cx="50%" cy="50%" r="49%"></circle>
+                    <text
+                      x="50%"
+                      y="50%"
+                      text-anchor="middle"
+                      dy="0.3em"
+                      fill="white"
+                      stroke="none"
+                    >
+                      ${result[1].votes}
+                    </text>
+                  </svg>
+                  <span
+                    style="margin-top: 10px;
+                    max-width: calc(${radius[1] *
+                    2} * 100vw * var(--svg-normalizer))"
+                    >${result[1].text}</span
+                  >
+                  <span>${result[1].votes}</span>
+                </div>
+                <div
+                  class="result-visual__svgContainer"
+                  style="margin-top: 40px;"
+                >
+                  <svg
+                    style="stroke: white;
+                  width: calc(${radius[2] * 2} * 100vw * var(--svg-normalizer));
+                  height: calc(${radius[2] *
+                    2} * 100vw * var(--svg-normalizer));"
+                  >
+                    <circle cx="50%" cy="50%" r="49%"></circle>
+                    <text
+                      x="50%"
+                      y="50%"
+                      text-anchor="middle"
+                      dy="0.3em"
+                      fill="white"
+                      stroke="none"
+                    >
+                      ${result[2].votes}
+                    </text>
+                  </svg>
+                  <span
+                    style="margin-top: 10px;
+                    max-width: calc(${radius[2] *
+                    2} * 100vw * var(--svg-normalizer))"
+                    >${result[2].text}</span
+                  >
+                  <span>${result[2].votes}</span>
+                </div>
+              </div>
+            </div>
+          </section>
+        </section>
+      </body>
+    </html>
+  `;
+};


### PR DESCRIPTION
This PR adds a view for the results page according to the design on figma. In the code there are views and frontend. I have decided to add the result page in views as it doesn't need any js. It can be rendered server-side.

The issue asked that the size of the circles should be proportional and linear. That is, if a proposal receives twice the votes its size should be 2x. However, I have added quadratic scaling. That is, the size difference between bigger votes will be less when compared to smaller votes. This results in a smoother result. If a proposal receives very few votes, the quadratic scaling ensures that it doesn't get too small.

Algorithm:
```js
result = [
  { optionID: 1, votes: 950, text: "Bundeskunsthalle’s proposal" },
  { optionID: 3, votes: 130, text: "Public good's proposal" },
  { optionID: 2, votes: 340, text: "DoD’s proposal" }
]
radius = result.map(({ votes }) => Math.sqrt(votes / totalVotes)); // This value is further normalised into pixels
```

If you want linear scaling,
```diff
- radius = result.map(({ votes }) => Math.sqrt(votes / totalVotes));
+ radius = result.map(({ votes }) => votes / totalVotes); 
```

For mobile I have just scaled down the circles. It looks good imo.

### Screenshots

![localhost_3000_result](https://user-images.githubusercontent.com/4337699/149222541-a925bb31-d7da-4b15-99ac-54012f67c139.png)
<img src="https://user-images.githubusercontent.com/4337699/149222581-3c4b9a8a-f38e-4d36-afca-d4f91cd431f0.png" width="400px" />


