### PR TITLE
enable WAL mode for sqlite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules
 strike.db
 test.db
 test.db-journal
+test.db-*
 test.html
 src/public/result.mp4
 src/public/bundle.js

--- a/src/db.mjs
+++ b/src/db.mjs
@@ -53,8 +53,12 @@ export function init(options) {
   }
 
   options = { ...database.options, ...options };
+  const db = sqlite3(name, options);
 
-  return sqlite3(name, options);
+  if(db.pragma('journal_mode = WAL', { simple: true }) !== 'wal')
+    console.info("Couldn't turn on WAL mode for sqlite3");
+  
+  return db
 }
 
 export const migrations = {

--- a/test/db_test.mjs
+++ b/test/db_test.mjs
@@ -145,6 +145,10 @@ test.serial("if init allows overwriting options", async t => {
     "better-sqlite3": {
       default: (name, options) => {
         t.is(options.verbose, null);
+
+        return {
+          pragma: () => {}
+        }
       }
     }
   });


### PR DESCRIPTION
Closes #84 

I couldn't find a build flag. However, there is this method written in the better-sqlite3 docs.
https://github.com/JoshuaWise/better-sqlite3/blob/master/docs/performance.md

Question: If I am correct, the `init` function creates db connection every time it is called. Shouldn't we cache the db connection?