### PR TITLE
correct `votes.tally` test

### DIFF
--- a/src/db.mjs
+++ b/src/db.mjs
@@ -146,7 +146,7 @@ export const votes = {
   },
   tally: function(questionID) {
     // Provided a question, this function returns the votes received by
-    // each option. For eg, [{ optionID: 1, votes: 2 }, { optionID: 2, votes: 3 }]
+    // each option. For eg, [{ optionID: 1, votes: 2, text: 'Option 1' }, { optionID: 2, votes: 3, text: 'Option 2' }, { optionID: 3, votes: 0, text: 'Option 3' }]
     const db = init();
     const question = questions.getWithOptions(questionID);
     const result = db
@@ -166,9 +166,9 @@ export const votes = {
       )
       .all({ questionID });
     for (let option of question.options) {
-      const included = result.find(({ optionId }) => optionId === option.ksuid);
+      const included = result.find(({ optionID }) => optionID === option.ksuid);
       if (!included) {
-        result.push({ optionId: option.ksuid, votes: 0 });
+        result.push({ optionID: option.ksuid, votes: 0, text: option.name });
       }
     }
     return result;


### PR DESCRIPTION
Earlier the result from `votes.tally` used to look like,
```js
[
  {
    optionID: '2467y3kRa3s5m7KVsoojqbqsvLZ',
    votes: 2,
  },
  {
    optionID: '2467y7Ia1Oy04GB7CTmZfEp6lUm',
    votes: 1,
  }
]
```

Now, they look like,
```js
[
  {
    optionID: '2467y3kRa3s5m7KVsoojqbqsvLZ',
    votes: 2,
    text: 'Tomatos'
  },
  {
    optionID: '2467y7Ia1Oy04GB7CTmZfEp6lUm',
    votes: 1,
    text: 'Bananas'
  },
  {
    optionID: '2467y4CYJ22UX2LPlCkYUIqz0j9',
    votes: 0,
    text: 'I like hamsters'
  }
]
```

This PR fixes the test according to the above mentioned change.

After changing the tests I found them to be still failing. That's when I found a bug in `db.mjs`.
```diff
     for (let option of question.options) {
-      const included = result.find(({ optionId }) => optionId === option.ksuid);
+      const included = result.find(({ optionID }) => optionID === option.ksuid);
       if (!included) {
-        result.push({ optionId: option.ksuid, votes: 0 });
+        result.push({ optionID: option.ksuid, votes: 0, text: option.name });
       }
     }
```